### PR TITLE
chore(npm): engine node >= 4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/arlac77/uti.git"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.2"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
at least node 4.2 is required