### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_script:
   - npm install -g --production coveralls codecov
 script:
   - npm run cover
+  - npm run lint
+  - npm run docs
 after_script:
   - codecov
   - cat ./build/coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![npm](https://img.shields.io/npm/v/uti.svg)](https://www.npmjs.com/package/uti)
 [![Greenkeeper](https://badges.greenkeeper.io/arlac77/uti.svg)](https://greenkeeper.io/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/arlac77/uti)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![Build Status](https://secure.travis-ci.org/arlac77/uti.png)](http://travis-ci.org/arlac77/uti)
 [![bithound](https://www.bithound.io/github/arlac77/uti/badges/score.svg)](https://www.bithound.io/github/arlac77/uti)
 [![codecov.io](http://codecov.io/github/arlac77/uti/coverage.svg?branch=master)](http://codecov.io/github/arlac77/uti?branch=master)
 [![Coverage Status](https://coveralls.io/repos/arlac77/uti/badge.svg)](https://coveralls.io/r/arlac77/uti)
-
 [![Known Vulnerabilities](https://snyk.io/test/github/arlac77/uti/badge.svg)](https://snyk.io/test/github/arlac77/uti)
 [![GitHub Issues](https://img.shields.io/github/issues/arlac77/uti.svg?style=flat-square)](https://github.com/arlac77/uti/issues)
 [![Stories in Ready](https://badge.waffle.io/arlac77/uti.svg?label=ready&title=Ready)](http://waffle.io/arlac77/uti)
@@ -15,6 +15,7 @@
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![downloads](http://img.shields.io/npm/dm/uti.svg?style=flat-square)](https://npmjs.org/package/uti)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+
 
 uti
 ===

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "cover": "nyc --temp-directory build/nyc ava",
     "test": "ava",
-    "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md",
+    "docs": "documentation readme src/uti.js --section=API",
     "semantic-release": "semantic-release",
     "pretest": "rollup -c tests/rollup.config.js",
     "posttest": "npm run prepare && markdown-doctest",
     "precover": "rollup -c tests/rollup.config.js",
-    "prepare": "rollup -c"
+    "prepare": "rollup -c",
+    "lint": "documentation lint src/uti.js"
   },
   "repository": {
     "type": "git",
@@ -22,14 +23,12 @@
   },
   "devDependencies": {
     "ava": "^0.24.0",
-    "jsdoc-babel": "^0.3.0",
-    "jsdoc-to-markdown": "^3.0.2",
     "markdown-doctest": "^0.9.1",
     "nyc": "^11.4.1",
     "rollup": "^0.52.3",
     "semantic-release": "^11.0.2",
     "xo": "^0.19.0",
-    "babel-preset-env": "^1.6.1"
+    "documentation": "^5.3.5"
   },
   "keywords": [
     "MIME",


### PR DESCRIPTION
package.json
---
- chore(devDependencies): remove jsdoc-babel@^0.3.0
- chore(devDependencies): remove jsdoc-to-markdown@^3.0.2
- chore(devDependencies): add documentation@^5.3.5 from template
- chore(scripts): update docs@documentation readme src/uti.js --section=API from template
- chore(scripts): add lint@documentation lint src/uti.js from template

.travis.yml
---
- chore(travis): merge from template .travis.yml

README.md
---
- docs(README): update from template
